### PR TITLE
system: set tracking param in constructor

### DIFF
--- a/src/System.cc
+++ b/src/System.cc
@@ -193,6 +193,8 @@ System::System(const string &strVocFile, const string &strSettingsFile, const eS
     mpTracker = new Tracking(this, mpVocabulary, mpFrameDrawer, mpMapDrawer,
                              mpAtlas, mpKeyFrameDatabase, strSettingsFile, mSensor, settings_, strSequence);
 
+    setTrackingParam(0.9);
+
     //Initialize the Local Mapping thread and launch
     mpLocalMapper = new LocalMapping(this, mpAtlas, mSensor==MONOCULAR || mSensor==IMU_MONOCULAR,
                                      mSensor==IMU_MONOCULAR || mSensor==IMU_STEREO || mSensor==IMU_RGBD, strSequence);


### PR DESCRIPTION
I couldn't manage to set it outside. Each time
I had a problem with segmentation. If it will be
needed, then I will try to do it somehow.